### PR TITLE
Fixing refrence from Invitation.py to InvitationText.py

### DIFF
--- a/getvite_api/app/controllers/Invitations.py
+++ b/getvite_api/app/controllers/Invitations.py
@@ -12,7 +12,7 @@ class Invitations:
         self.sessionmaker = dbconnection.sessionmaker
 
     def get_invitation_by_admin_user(self, session, user):
-        invitation_text_query_array = session.query(InvitationText).filter(Invitation.admin_user==user).all()
+        invitation_text_query_array = session.query(InvitationText).filter(InvitationText.invitation_admin_user==user).all()
         size = len(invitation_text_query_array)
         invitation_text = [None] * size
         for invitation_text_row in invitation_text_query_array:


### PR DESCRIPTION
### what

In controlers/Invitations.py
There was an issue when filtering the texts belonging to a specific user.

### how
Changed reference from models/Invitation.py to models/InvitationText.py
