### PR TITLE
Persist deletion to backend

### DIFF
--- a/getvite_api/DB/bootstrap_db.sql
+++ b/getvite_api/DB/bootstrap_db.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS invitations (
 
 CREATE TABLE IF NOT EXISTS invitation_text (
   invitation_admin_user STRING REFERENCES invitations(admin_user) ON DELETE CASCADE, 
-  text_id INT,
+  text_id UUID DEFAULT gen_random_uuid(),
   text STRING,
   text_position INT,
   font_size STRING,

--- a/getvite_api/app/controllers/Invitations.py
+++ b/getvite_api/app/controllers/Invitations.py
@@ -19,7 +19,8 @@ class Invitations:
             invitation_text.append({
                     "text": invitation_text_row.text,
                     "position": invitation_text_row.text_position,
-                    "fontSize": invitation_text_row.font_size
+                    "fontSize": invitation_text_row.font_size,
+                    "textId": invitation_text_row.text_id
                     })
 
         invitations = []
@@ -39,34 +40,32 @@ class Invitations:
 
     def save_invitation_text(self, session, user, invitation_text):
         invitation_text_to_save = []
-        count = 0
         print(invitation_text)
         for invitation_text_row in invitation_text:
-            if invitation_text_row['isDeleted']:
+            updated = 0
+            if "new_text_box" not in invitation_text_row['textId'] and invitation_text_row['isDeleted']:
                 updated = session.query(InvitationText).\
                         filter(InvitationText.invitation_admin_user==user).\
-                        filter(InvitationText.text_id==count).\
+                        filter(InvitationText.text_id==uuid.UUID(invitation_text_row['textId']).hex).\
                         delete(synchronize_session=False)
-            else:
+            elif "new_text_box" not in invitation_text_row['textId']:
                 updated = session.query(InvitationText).\
                         filter(InvitationText.invitation_admin_user==user).\
-                        filter(InvitationText.text_id==count).\
+                        filter(InvitationText.text_id==uuid.UUID(invitation_text_row['textId']).hex).\
                         update({
                             'text': invitation_text_row['text'],
                             'text_position': invitation_text_row['position'],
                             'font_size': invitation_text_row['fontSize']
                             })
-            if updated == 0:
+            if not invitation_text_row['isDeleted'] and updated == 0:
                 invitation_text_to_save.append(
                         InvitationText(
                             invitation_admin_user=user,
-                            text_id=count,
                             text=invitation_text_row['text'],
                             text_position=invitation_text_row['position'],
                             font_size=invitation_text_row['fontSize']
                             )
                         )
-            count += 1
         session.add_all(invitation_text_to_save)
 
     def save_invitation_text_transaction(self, user, invitation_text):

--- a/getvite_api/app/models/InvitationText.py
+++ b/getvite_api/app/models/InvitationText.py
@@ -7,7 +7,7 @@ Base = declarative_base()
 class InvitationText(Base):
     __tablename__ = 'invitation_text'
     invitation_admin_user = Column(ForeignKey(Invitation.admin_user), primary_key=True)
-    text_id = Column(String, primary_key=True)
+    text_id = Column(Unicode, primary_key=True)
     text = Column(String)
     text_position = Column(Integer)
     font_size = Column(String)

--- a/getvite_app/src/actions/index.js
+++ b/getvite_app/src/actions/index.js
@@ -6,6 +6,7 @@ export const ADD_INVITATION_TEXT_TEXT = 'ADD_INVITATION_TEXT_TEXT'
 export const ADD_INVITATION_TEXT_POSITION = 'ADD_INVITATION_TEXT_POSITION'
 export const ADD_INVITATION_TEXT_FONTSIZE = 'ADD_INVITATION_TEXT_FONTSIZE'
 export const DELETE_INVITATION_TEXTBOX = 'DELETE INVITATION TEXTBOX'
+export const DELETE_INVITATION_TEXTBOXES = 'DELETE_INVITATION_TEXTBOXES'
 
 
 export function addInvitation ({ invitation }) {
@@ -45,6 +46,12 @@ export function deleteInvitationTextbox ( {textId, isDeleted } ) {
     type: DELETE_INVITATION_TEXTBOX,
     textId,
     isDeleted,
+  }
+}
+
+export function deleteInvitationTextboxes () {
+  return {
+    type: DELETE_INVITATION_TEXTBOXES,
   }
 }
 

--- a/getvite_app/src/components/Invitation.js
+++ b/getvite_app/src/components/Invitation.js
@@ -2,10 +2,11 @@ import React, { Component } from 'react';
 import { Route, Link, Switch } from 'react-router-dom'
 import { connect } from 'react-redux'
 import './css/Invitation.css';
-import { addInvitationText } from '../actions'
+import { addInvitationText, deleteInvitationTextboxes } from '../actions'
 import InvitationText from './InvitationText';
 import { RiAddBoxLine, RiSaveLine, RiEditBoxLine } from 'react-icons/ri'
 import * as Api from '../utils/api'
+import * as ApiController from '../utils/apiController'
 
 class Invitation extends Component {
   state = {
@@ -24,6 +25,8 @@ class Invitation extends Component {
             ...this.state,
             edit: newEditState
           }))
+          this.props.deleteInvitationTextboxes()
+          this.props.fetchInvitation(user)
         } else{
           console.log("Error Saving to DB")
         }
@@ -56,7 +59,7 @@ class Invitation extends Component {
              > 
              <RiAddBoxLine
                className="Invitation-addbox"
-               onClick={(event => this.handleMakeNewText(this.props.numberText + 1, 5+12*this.props.numberText, "20"))}
+               onClick={(event => this.handleMakeNewText("new_text_box" + (this.props.numberText + 1).toString(), 5, "20"))}
               />
             </div>
            </div>
@@ -103,6 +106,8 @@ function mapStateToProps({ invitation }, props ) {
 function mapDispatchToProps( dispatch ){
   return {
     addInvitationText: (data) => dispatch(addInvitationText(data)),
+    fetchInvitation: (data) => dispatch(ApiController.fetchInvitation(data)),
+    deleteInvitationTextboxes: () => dispatch(deleteInvitationTextboxes()),
   }
 }
 

--- a/getvite_app/src/reducers/index.js
+++ b/getvite_app/src/reducers/index.js
@@ -8,6 +8,7 @@ import {
   ADD_INVITATION_TEXT_POSITION,
   ADD_INVITATION_TEXT_FONTSIZE,
   DELETE_INVITATION_TEXTBOX,
+  DELETE_INVITATION_TEXTBOXES,
 } from '../actions'
 
 function invitation (state={}, action) {
@@ -91,6 +92,12 @@ function invitation (state={}, action) {
             ...state['text'][textId],
             isDeleted: isDeleted
           }
+        }
+      }
+    case DELETE_INVITATION_TEXTBOXES:
+      return {
+        ...state,
+        'text': {
         }
       }
     default:

--- a/getvite_app/src/utils/apiController.js
+++ b/getvite_app/src/utils/apiController.js
@@ -8,17 +8,15 @@ export const fetchInvitation = (admin_user) => dispatch => (
     if(invitation.user == admin_user){
       dispatch(addInvitation({ invitation }))
       dispatch(addInvitationUser({ username: admin_user, isAdmin: true }))
-      let count = 0
       invitation.text.forEach(function(text_attributes){
         dispatch(addInvitationText(
           {
-            textId: count,
+            textId: text_attributes.textId,
             invitationText: text_attributes.text,
             invitationTextPosition: text_attributes.position,
             invitationTextFontSize: text_attributes.fontSize
           }
         )) 
-        count += 1
       })
     }
   })


### PR DESCRIPTION
### What
Currently when deleting, deletion simply takes place on react front end state by marking box as delete, this pr provides logic to persist this deletion to the database.

### How
On save, and if isDelete true, removed from the database. Given that we are now removing textBox from the database we no longer can rely on the textId being the count on the textboxes, since on deletion this count gets distorted.

example given textBoxes with textIds [1,2,3,4,5] deleting 3 then gives [1,2,4,5] generating new text box would then generate a text box with textId of len([1,2,4,5]) + 1 which gives 5 which collides with existing textId 5. 

thus logic has been changed to use the backend DB to generate a unique ID. Logic is as follows:

1. generate new text box with temp textId on create:  "new_text_box{number}"
2. on save check if textId is "new_text_box{number}" thus we know its a new entry and we input into database and have database generate new UUID(unique ID)
3. on save being successful, remove all react text state from front end and recreated the state by querying the back end database, this brings forward the UUID to the front end.

### Test
Top hat(test by running the application clicking GUI) 
- generate box, save box, 
- generate box, delete box, save box
- generate box, save box, delete box, save
all works as expected
